### PR TITLE
feat: Changed Notes ListView to Staggered GridView

### DIFF
--- a/app/src/main/java/com/example/notesappcompose/feature_note/presentation/notes/NotesScreenUI.kt
+++ b/app/src/main/java/com/example/notesappcompose/feature_note/presentation/notes/NotesScreenUI.kt
@@ -1,5 +1,6 @@
 package com.example.notesappcompose.feature_note.presentation.notes
 
+import android.util.Log
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -16,6 +17,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Sort
@@ -67,10 +71,10 @@ fun NotesScreen(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(16.dp)
+
             ) {
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth().padding(16.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
@@ -104,11 +108,12 @@ fun NotesScreen(
 
                 Spacer(modifier = Modifier.height(16.dp))
 
-                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                LazyVerticalStaggeredGrid(columns = StaggeredGridCells.Fixed(2), modifier = Modifier.fillMaxSize()) {
                     items(state.notes) { note ->
                         NoteItemUI(
                             note = note,
                             modifier = Modifier
+                                .padding(8.dp)
                                 .fillMaxWidth()
                                 .clickable {
                                     //clicking on individual note


### PR DESCRIPTION
Hi there @utkarsh006, as per the issue mentioned in #13 

I have updated the list view into grid view, and it looks pretty awesome now!
And also the newly added notes will stay at the top, so that recently added can be viewed easily by the user

<table>
<tr>
<th>
Notes List (Before)
</th>
<th>
Notes List (After)
</th>
</tr>
<tr>
<td>
<img src="https://github.com/utkarsh006/Notes-app-compose/assets/95350584/2fa5c538-907d-4f3c-8261-171b1bba86e0" width="300" />
</td>
<td>
<img src="https://github.com/utkarsh006/Notes-app-compose/assets/95350584/c3eafc81-7837-49e8-9494-885fbe71da53" width="300" />
</td>
</tr>
</table>

Kindly review the issue and PR as well 👍

#Hacktoberfest2023